### PR TITLE
Make link to next section visible

### DIFF
--- a/WebApplication/3_ServerlessBackend/README.md
+++ b/WebApplication/3_ServerlessBackend/README.md
@@ -438,7 +438,6 @@ For this module you will test the function that you built using the AWS Lambda c
     }
 }
 ```
+</details>
 
 After you have successfully tested your new function using the Lambda console, you can move on to the next module, [RESTful APIs](../4_RESTfulAPIs).
-
-</details>


### PR DESCRIPTION
Previously this link was hidden in the details section, with no other clear way to proceed when the module is complete.